### PR TITLE
Fix firefox compatibility for keyboard input

### DIFF
--- a/src/calculator/components/keyboard/keyboard.tsx
+++ b/src/calculator/components/keyboard/keyboard.tsx
@@ -15,7 +15,7 @@ export default class Keyboard extends React.Component<Props, object> {
   }
 
   handleKeyPress(event: KeyboardEvent) {
-    if (event.keyCode === SPACE_KEY) {
+    if (event.keyCode === SPACE_KEY || event.code === 'Space') {
       this.monkeys.toggleMonkeys();
     }
   }


### PR DESCRIPTION
KeyboardEvent.keyCode is deprecated: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

Use KeyboardEvent.key as well for Firefox compatibility